### PR TITLE
Issue #45: support for preventing spinner from hiding on Android back

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,12 +41,17 @@ npm install --save react-native-loading-spinner-overlay@0.1.x
 
 This usage shows the default styles and properties.
 
-* You can pass a String `size` prop that can either be `"large"` or `"small"` (no other cross-platform sizes are supported right now, and by default it is `"large"`)
-* You can pass a String `color` ColorProp (e.g. `red` or `#ff0000`) to change the default spinner color (by default it is `"white"` for high contrast on the default `overlayColor`; see below)
-* You can control visibility of the spinner using the Boolean prop `visible` (Boolean, by default it is `false`)
-* To change the color of the overlay, pass a ColorProp as the `overlayColor` prop (e.g. `'rgba(0,0,0,0.25)'`)
-* Optional text field, activate by passing textContent Prop and style by passing textStyle Prop
-* You can also pass a custom view to act as activity indicator.
+| Property      | Type             | Default  | Description  |
+| ------------- |----------------| --------|-------------|
+| cancelable  | `boolean`      |    `true` | **Android**: If set to false, it will prevent spinner from hiding when pressing the hardware back button.|
+| color         | `string`      |   `white` | Changes the spinner's color (example values are `red`, `#ff0000`, etc). For adjusting the contrast see `overlayColor` prop below.|
+| overlayColor  | `string`      |    `rgba(0, 0, 0, 0.25)` | Changes the color of the overlay.|
+| size          | `small`, `normal`, `large` | `large ` | Sets the spinner's size. No other cross-platform sizes are supported right now.|
+| textContent  | `string`      |    `""` | Optional text field to be shown.|
+| textStyle  | `style`      |    `-` | The style to be applied to the `<Text>` that displays the `textContent`.|
+| visible  | `boolean`      |    `false` | Controls the visibility of the spinner.|
+
+You can also add a child view to act as a custom activity indicator.
 
 ```js
 import React, { View, Text } from 'react-native';

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ export default class Spinner extends React.Component {
 
   static propTypes = {
     visible: React.PropTypes.bool,
+    cancelable: React.PropTypes.bool,
     textContent: React.PropTypes.string,
     color: React.PropTypes.string,
     size: React.PropTypes.oneOf(SIZES),
@@ -80,6 +81,7 @@ export default class Spinner extends React.Component {
 
   static defaultProps = {
     visible: false,
+    cancelable: true,
     textContent: "",
     color: 'white',
     size: 'large', // 'normal',
@@ -93,6 +95,12 @@ export default class Spinner extends React.Component {
   componentWillReceiveProps(nextProps) {
     const { visible, textContent } = nextProps;
     this.setState({ visible, textContent });
+  }
+
+  _handleOnRequestClose() {
+    if (this.props.cancelable) {
+      this.close();
+    }
   }
 
   _renderDefaultContent() {
@@ -128,7 +136,7 @@ export default class Spinner extends React.Component {
 
     return (
       <Modal
-        onRequestClose={() => this.close()}
+        onRequestClose={() => this._handleOnRequestClose()}
         supportedOrientations={['landscape', 'portrait']}
         transparent
         visible={visible}>


### PR DESCRIPTION
On Android there's the need of preventing spinner from hiding when pressing the hardware back button. This can be resolved by setting the new prop `cancelable` to `false` -by default it's `true`. 

This has no effect on iOS as the Modal's `onRequestClose` prop is Android-specific.