### PR TITLE
When the spinner is invisible, return nothing.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,10 +120,9 @@ export default class Spinner extends React.Component {
   _renderSpinner() {
     const { visible } = this.state;
 
-    if (!visible)
-      return (
-        <View />
-      );
+    if (!visible) {
+      return null;
+    }
 
     const spinner = (
       <View style={[


### PR DESCRIPTION
The empty view previously returned can affect layout in some
situations, such as if its parent has justify-content:'space-between'.
That would cause the layout to jump when the spinner became visible
and gained the position:'absolute' property.

Note that because this can affect layout in the invisible case, it should
probably be released with a minor version bump.