### PR TITLE
When the spinner is hidden, hide the stub view.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export default class Spinner extends React.Component {
 
     if (!visible)
       return (
-        <View />
+        <View display="none" />
       );
 
     const spinner = (

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
     right: 0,
     justifyContent: 'center',
     alignItems: 'center',
-    position: 'absolute',
+    position: 'absolute'
   },
   textContent: {
     top: 80,
@@ -82,7 +82,7 @@ export default class Spinner extends React.Component {
   static defaultProps = {
     visible: false,
     cancelable: false,
-    textContent: "",
+    textContent: '',
     color: 'white',
     size: 'large', // 'normal',
     overlayColor: 'rgba(0, 0, 0, 0.25)'


### PR DESCRIPTION
The problem with returning `<View />` is that it still counts as a
flexbox child and thus takes up space in the layout. Adding and
removing the spinner in that situation causes the layout to jump
around.

Returning null would also be a reasonable solution, but in practice
it seemed to cause a layout bug on Android wherein the spinner overlay
wouldn't fully disappear.

Returning a hidden view solves both of these problems.

This PR includes a bonus commit to fix the build.