### PR TITLE
Use PropTypes as separated package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "eslint": "^3.2.0",
     "eslint-config-crocodile": "^1.0.0",
     "eslint-plugin-react": "^5.2.2",
-    "eslint-plugin-react-native": "^1.2.0"
+    "eslint-plugin-react-native": "^1.2.0",
+    "prop-types": "^15.5.10"
   },
   "homepage": "https://github.com/joinspontaneous/react-native-loading-spinner-overlay",
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@
 //
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   StyleSheet,
   View,
@@ -71,12 +72,12 @@ export default class Spinner extends React.Component {
   }
 
   static propTypes = {
-    visible: React.PropTypes.bool,
-    cancelable: React.PropTypes.bool,
-    textContent: React.PropTypes.string,
-    color: React.PropTypes.string,
-    size: React.PropTypes.oneOf(SIZES),
-    overlayColor: React.PropTypes.string
+    visible: PropTypes.bool,
+    cancelable: PropTypes.bool,
+    textContent: PropTypes.string,
+    color: PropTypes.string,
+    size: PropTypes.oneOf(SIZES),
+    overlayColor: PropTypes.string
   };
 
   static defaultProps = {


### PR DESCRIPTION
This update prevents the warning by React.PropTypes depreciation