### PR TITLE
Stop returning null when visible changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,8 +136,6 @@ export default class Spinner extends React.PureComponent {
   }
 
   _renderSpinner() {
-    if (!this.state.visible) return null;
-
     const spinner = (
       <View
         style={[styles.container, { backgroundColor: this.props.overlayColor }]}


### PR DESCRIPTION
Returning null wipes out the modal component, if the state changes too quickly this causes the modal to get stuck on the screen even between reloads. Better to let the modal handles its own visibility change.

This should fix #83 and may have positive impacts on #82 #72 and #61  (no guarantee on the latter ones).